### PR TITLE
add node/edge sync primitive that can't miss an update

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -8988,3 +8988,48 @@ I am going to commit this now,
 and next I'll just kinda start a whole new sync primitive for the edge and node system
 because I just thought of a nice implementation for it,
 and I want to feel productive.
+
+2026-07-27 (later)
+
+Wrote that sync primitive: `sonamu_sync::node_edge`.
+(This entry is a design note, not stream-of-consciousness, so rewrite it in your own voice if you want.)
+
+The rule that makes it work: **a node's lock and its edges' locks are different locks**,
+and the node's own lock guards nothing but a counter of how many times peers have poked it.
+
+- `Node` = a thread. `node_a.connect_to(&node_b, shared)` makes an edge and hands back
+  `(a's end, b's end)`. Writing through an end wakes the node at the *other* end,
+  so the two ends are not interchangeable and you can not accidentally notify yourself.
+- `node.watch()` snapshots the poke counter. You take it **before** looking at your edges
+  and hand it to `node.wait(watch)` **after**. If anything poked you in between, `wait`
+  refuses to sleep. That is the whole fix for the missed-update problem:
+  the check and the sleep are one step, because the check happens under the node lock
+  and a poker has to take that same lock to bump the counter.
+- Counter instead of a bool because a bool has to be cleared, and clearing it after
+  handling throws away pokes that arrived *during* the handling.
+- `node.run(|| ... ControlFlow)` is that loop written correctly once, so I do not have to
+  re-derive it at every call site.
+- Notifying is automatic: `EdgeGuard`'s `DerefMut` marks the edge dirty and the peer gets
+  poked when the guard drops (after the edge is unlocked, so it does not wake up just to
+  block). No more "I forgot to notify the condvar on keypress".
+  `guard.quiet_mut()` is the opt-out, for when I am *consuming* rather than producing
+  (draining my own inbox) -- that is what stops two nodes from notifying each other forever.
+- One condvar per *node*, not one shared by everything, which was the other thing I
+  wanted to fix.
+
+Why it can not deadlock: a node lock is a **leaf** (nothing is ever locked while one is
+held, and waiting releases it), so the new locks can not be part of a cycle. The edge locks
+are the same as before: one at a time, and the graph is a tree.
+Falling asleep while holding an edge would wedge the peer forever, so `wait` panics
+instead of hanging (thread-local guard count).
+
+`cargo run -p sonamu_sync --example tree` runs the ui/runner/applet shape,
+where the runner is a middle node with two edges. That is the topology `singularity_sar`
+needs, so migrating `runner.rs` off `SharedData` should mostly be mechanical:
+one `Node` per thread, `UIState` and `RootAppletState` become the two edges,
+`lock_state()` becomes `end.lock()`, `notify()` disappears, and the main loop body
+becomes the closure passed to `run`.
+
+The tests in `sonamu_sync/tests/node_edge.rs` are all written so a lost update shows up
+as a hang (each one runs behind a deadline). Checked they actually catch it by breaking
+`wait` on purpose to ignore the watch: 5 of the 12 fail, which is what I wanted to see.

--- a/singularity_common/sonamu_sync/examples/tree.rs
+++ b/singularity_common/sonamu_sync/examples/tree.rs
@@ -1,0 +1,155 @@
+//! A middle node with two edges: the shape `singularity_sar`'s main loop has.
+//!
+//! ```text
+//!     ui  <--(events, frame)-->  runner  <--(events, content)-->  applet
+//! ```
+//!
+//! The runner sleeps once and wakes for whichever side moved, and neither side
+//! can lose an update by writing while the runner is between "handled
+//! everything" and "asleep".
+//!
+//! Note that the runner never holds both edges at once, and that "is it still
+//! running" is duplicated per edge rather than shared: the ui and the applet are
+//! not neighbours, so they must never be able to lock each other.
+//!
+//! Run with: `cargo run -p sonamu_sync --example tree`
+
+use sonamu_sync::node_edge::{EdgeEnd, Node};
+use std::{ops::ControlFlow, thread, time::Duration};
+
+const EVENTS: usize = 5;
+
+/// The state shared by the ui thread and the runner.
+#[derive(Default)]
+struct UiEdge {
+    /// ui -> runner
+    events: Vec<String>,
+    /// runner -> ui
+    frame: Option<String>,
+    /// runner -> ui
+    quit: bool,
+}
+
+/// The state shared by the runner and the applet.
+#[derive(Default)]
+struct AppletEdge {
+    /// runner -> applet
+    events: Vec<String>,
+    /// applet -> runner
+    content: Option<String>,
+    /// applet -> runner: the applet asked to be closed
+    closed: bool,
+}
+
+fn main() {
+    let ui = Node::new();
+    let runner = Node::new();
+    let applet = Node::new();
+
+    // the tree: ui --- runner --- applet
+    let (runner_to_ui, ui_end) = runner.connect_to(&ui, UiEdge::default());
+    let (runner_to_applet, applet_end) = runner.connect_to(&applet, AppletEdge::default());
+
+    let ui_thread = thread::spawn(move || run_ui(&ui, &ui_end));
+    let applet_thread = thread::spawn(move || run_applet(&applet, &applet_end));
+
+    run_runner(&runner, &runner_to_ui, &runner_to_applet);
+
+    ui_thread.join().unwrap();
+    applet_thread.join().unwrap();
+    println!("[runner] everyone is home");
+}
+
+/// Pretends to be a window: makes up an event every so often, draws frames.
+fn run_ui(ui: &Node, edge: &EdgeEnd<UiEdge>) {
+    {
+        // a real ui thread has its own event loop, so it just spawns a poker
+        let edge = edge.clone();
+        thread::spawn(move || {
+            for event in 0..EVENTS {
+                thread::sleep(Duration::from_millis(40));
+                edge.lock().events.push(format!("key #{event}"));
+            }
+        });
+    }
+
+    ui.run(|| {
+        let mut ui_edge = edge.lock();
+
+        if ui_edge.quit {
+            println!("[ui] closing");
+            return ControlFlow::Break(());
+        }
+
+        // taking the frame is consuming, not producing: `quiet_mut` so the
+        // runner is not woken up by us reading its mail
+        if let Some(frame) = ui_edge.quiet_mut().frame.take() {
+            println!("[ui] drawing {frame:?}");
+        }
+
+        ControlFlow::Continue(())
+    });
+}
+
+/// Pretends to be an applet: turns events into content, and closes itself once
+/// it has had enough.
+fn run_applet(applet: &Node, edge: &EdgeEnd<AppletEdge>) {
+    let mut handled = 0;
+
+    applet.run(|| {
+        let mut applet_edge = edge.lock();
+
+        for event in applet_edge.quiet_mut().events.drain(..) {
+            handled += 1;
+            println!("[applet] handling {event:?}");
+        }
+
+        if handled == 0 {
+            return ControlFlow::Continue(());
+        }
+
+        // `DerefMut`, so dropping the guard wakes the runner up for us
+        applet_edge.content = Some(format!("{handled} event(s) so far"));
+
+        if handled == EVENTS {
+            println!("[applet] that is enough, closing");
+            applet_edge.closed = true;
+            return ControlFlow::Break(());
+        }
+
+        ControlFlow::Continue(())
+    });
+}
+
+/// The middle node: it has two edges and no idea which one will move next.
+fn run_runner(runner: &Node, to_ui: &EdgeEnd<UiEdge>, to_applet: &EdgeEnd<AppletEdge>) {
+    runner.run(|| {
+        // Handle *everything* that could have changed, one edge at a time.
+        // Anything that lands while we are in here bumps our poke count, so the
+        // `wait` at the bottom of `run` will not sleep on it.
+
+        let events = std::mem::take(&mut to_ui.lock().quiet_mut().events);
+        if !events.is_empty() {
+            to_applet.lock().events.extend(events);
+        }
+
+        let (content, closed) = {
+            let mut applet_edge = to_applet.lock();
+            let applet_edge = applet_edge.quiet_mut();
+
+            (applet_edge.content.take(), applet_edge.closed)
+        };
+
+        if let Some(content) = content {
+            to_ui.lock().frame = Some(content);
+        }
+
+        if closed {
+            println!("[runner] applet closed, telling the ui to quit");
+            to_ui.lock().quit = true;
+            return ControlFlow::Break(());
+        }
+
+        ControlFlow::Continue(())
+    });
+}

--- a/singularity_common/sonamu_sync/src/lib.rs
+++ b/singularity_common/sonamu_sync/src/lib.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, RwLock, atomic::AtomicUsize},
 };
 
+pub mod node_edge;
 pub mod shared_state;
 
 /// Lock (RwLock) but you can only call getter and setter,

--- a/singularity_common/sonamu_sync/src/node_edge.rs
+++ b/singularity_common/sonamu_sync/src/node_edge.rs
@@ -1,0 +1,498 @@
+//! Sleeping on a tree of threads without ever missing an update.
+//!
+//! # The model
+//!
+//! - A **node** is a thread. It owns exactly one [`Node`].
+//! - An **edge** is state shared by exactly two nodes. Access to it is mutually
+//!   exclusive, and each of the two nodes holds its own [`EdgeEnd`] of it.
+//! - A node may sleep until *any* of its edges is written to by a peer.
+//!
+//! Since the graph is a tree, locking a single edge can never deadlock,
+//! and this module never asks you to hold two locks at once.
+//!
+//! # The bug this exists to kill
+//!
+//! The obvious implementation (one mutex + one condvar per edge, wait on the
+//! condvar when there is nothing to do) drops updates:
+//!
+//! ```text
+//!  node A                              node B
+//!  ------                              ------
+//!  lock edge, handle everything
+//!  unlock edge
+//!                                      lock edge, write, unlock edge
+//!                                      notify   <-- nobody is listening yet, so this is lost
+//!  sleep
+//!  ...zzz (forever, even though there is work waiting)
+//! ```
+//!
+//! The window is between "I decided there was nothing left to do" and "I am
+//! actually asleep", so no amount of re-checking the edges closes it: the check
+//! and the sleep have to be *one atomic step*.
+//!
+//! # The fix
+//!
+//! Every node gets a **second, tiny lock of its very own**, holding nothing but a
+//! counter of how many times peers have poked this node. Peers bump that counter
+//! (never the sleeper), and it is the *only* thing the condvar is attached to.
+//!
+//! You take a [`Watch`] (a snapshot of the counter) **before** you look at your
+//! edges, and hand it back to [`Node::wait`] **after**:
+//!
+//! ```text
+//!  node A                              node B
+//!  ------                              ------
+//!  watch = 7
+//!  lock edge, handle everything
+//!  unlock edge
+//!                                      lock edge, write, unlock edge
+//!                                      counter := 8
+//!  wait(7): counter is 8, so do not sleep -- go around again
+//! ```
+//!
+//! and if B is a moment later instead, it has to take A's node lock to bump the
+//! counter, which A holds until the instant it falls asleep -- so the notify
+//! lands on a node that is provably already listening. There is no third case:
+//! either the counter moved before A slept (A does not sleep) or after (A is
+//! asleep and gets woken). **A cannot miss an update.**
+//!
+//! The rest is bookkeeping:
+//!
+//! - Writes notify the peer *automatically*, when the [`EdgeGuard`] is dropped
+//!   (see [`EdgeGuard::quiet_mut`] for the "I am consuming, not producing" case),
+//!   so you cannot forget to.
+//! - The notify happens *after* the write is published and the edge is unlocked.
+//! - A node lock is a **leaf**: no lock is ever taken while one is held, so
+//!   adding these locks cannot introduce a deadlock cycle.
+//! - Falling asleep while holding an edge would wedge the peer forever, so
+//!   [`Node::wait`] panics instead of hanging.
+//!
+//! # Example
+//!
+//! ```
+//! use sonamu_sync::node_edge::Node;
+//! use std::ops::ControlFlow;
+//!
+//! let parent = Node::new();
+//! let child = Node::new();
+//! // each side gets its own handle to the same state
+//! let (parent_end, child_end) = parent.connect_to(&child, Vec::<u32>::new());
+//!
+//! std::thread::spawn(move || {
+//!     for i in 0..10 {
+//!         child_end.lock().push(i); // dropping the guard wakes the parent
+//!     }
+//! });
+//!
+//! let mut seen = 0;
+//! parent.run(|| {
+//!     // `quiet_mut`: draining my inbox is not an update *for the child*
+//!     seen += parent_end.lock().quiet_mut().drain(..).count();
+//!     if seen == 10 { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
+//! });
+//! ```
+
+use std::{
+    cell::Cell,
+    fmt,
+    ops::{ControlFlow, Deref, DerefMut},
+    sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError},
+    time::Duration,
+};
+
+thread_local! {
+    /// How many edge guards *this thread* is currently holding.
+    ///
+    /// Purely a bug detector, see [`Node::wait`].
+    static HELD_EDGES: Cell<usize> = const { Cell::new(0) };
+}
+
+/// A thread, in the node-and-edge model. One per thread; it is what you sleep on.
+///
+/// Create the nodes first, [`connect_to`](Node::connect_to) them into a tree,
+/// then send each `Node` off to its thread.
+#[derive(Debug)]
+pub struct Node {
+    inner: Arc<NodeInner>,
+}
+
+/// The bit of a node that peers are allowed to touch.
+#[derive(Debug)]
+struct NodeInner {
+    /// A node's *own* lock, separate from any edge lock.
+    ///
+    /// This is a **leaf lock**: nothing else is ever locked while it is held
+    /// (waiting releases it), so it cannot take part in a deadlock cycle.
+    state: Mutex<NodeState>,
+    /// One condvar per *node*, not per edge: a node sleeps once and wakes for
+    /// whichever of its edges moved.
+    poked: Condvar,
+}
+
+#[derive(Debug)]
+struct NodeState {
+    /// How many times peers have poked this node, ever.
+    ///
+    /// A counter rather than a `bool` so that a node can snapshot it *before*
+    /// handling its edges and still detect a poke that arrived *during* the
+    /// handling. Clearing a flag afterwards would throw that poke away.
+    pokes: u64,
+}
+
+impl Node {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(NodeInner {
+                state: Mutex::new(NodeState { pokes: 0 }),
+                poked: Condvar::new(),
+            }),
+        }
+    }
+
+    /// Shares some state between this node and `other`, and hands each of them
+    /// their own end of it.
+    ///
+    /// Returns `(my end, their end)`. Writing through an end wakes the node at
+    /// the *other* end, which is why the two ends are not interchangeable.
+    #[must_use]
+    pub fn connect_to<Shared>(
+        &self,
+        other: &Self,
+        shared: Shared,
+    ) -> (EdgeEnd<Shared>, EdgeEnd<Shared>) {
+        let edge = Arc::new(Mutex::new(shared));
+
+        (
+            EdgeEnd {
+                edge: edge.clone(),
+                peer: other.poker(),
+            },
+            EdgeEnd {
+                edge,
+                peer: self.poker(),
+            },
+        )
+    }
+
+    /// A handle other threads can use to wake this node up, with no state attached.
+    ///
+    /// [`connect_to`](Node::connect_to) already wires these up for you; reach for
+    /// this when you want a bare "something happened" signal, or to wake
+    /// *yourself* later (a self-poke just means the next [`wait`](Node::wait)
+    /// returns immediately).
+    #[must_use]
+    pub fn poker(&self) -> Poker {
+        Poker {
+            node: self.inner.clone(),
+        }
+    }
+
+    /// A snapshot of "everything I have been told about so far".
+    ///
+    /// **Take this before you look at your edges.** Anything that happens after
+    /// this call makes the watch stale, and [`wait`](Node::wait) refuses to sleep
+    /// on a stale watch -- which is exactly what stops updates from being missed.
+    pub fn watch(&self) -> Watch {
+        Watch {
+            pokes: self.lock_state().pokes,
+            node: self.id(),
+        }
+    }
+
+    /// Whether a peer has poked this node since `watch` was taken.
+    ///
+    /// The non-blocking version of [`wait`](Node::wait), for a node that has its
+    /// own reasons to keep spinning (a render loop, say).
+    #[must_use]
+    pub fn has_update(&self, watch: Watch) -> bool {
+        debug_assert_eq!(watch.node, self.id(), "that `Watch` is another node's");
+
+        self.lock_state().pokes != watch.pokes
+    }
+
+    /// Sleeps until a peer touches one of this node's edges, and returns a fresh
+    /// [`Watch`] for the next round.
+    ///
+    /// Returns immediately if a poke landed after `watch` was taken -- so the
+    /// "handle everything, then sleep" race cannot lose an update.
+    ///
+    /// # Panics
+    ///
+    /// If the calling thread is still holding an [`EdgeGuard`]. That would block
+    /// the peer from ever writing to that edge, and therefore from ever waking
+    /// you up: a guaranteed hang, reported as a panic instead.
+    pub fn wait(&self, watch: Watch) -> Watch {
+        assert_can_sleep();
+        debug_assert_eq!(watch.node, self.id(), "that `Watch` is another node's");
+
+        let state = self
+            .inner
+            .poked
+            .wait_while(self.lock_state(), |state| state.pokes == watch.pokes)
+            .unwrap_or_else(PoisonError::into_inner);
+
+        Watch {
+            pokes: state.pokes,
+            node: self.id(),
+        }
+    }
+
+    /// [`wait`](Node::wait), but gives up after `timeout`.
+    ///
+    /// Returns the fresh watch, and whether it timed out (ie: nothing arrived).
+    ///
+    /// # Panics
+    ///
+    /// Same as [`wait`](Node::wait).
+    pub fn wait_timeout(&self, watch: Watch, timeout: Duration) -> (Watch, bool) {
+        assert_can_sleep();
+        debug_assert_eq!(watch.node, self.id(), "that `Watch` is another node's");
+
+        let (state, timed_out) = self
+            .inner
+            .poked
+            .wait_timeout_while(self.lock_state(), timeout, |state| {
+                state.pokes == watch.pokes
+            })
+            .unwrap_or_else(PoisonError::into_inner);
+
+        (
+            Watch {
+                pokes: state.pokes,
+                node: self.id(),
+            },
+            timed_out.timed_out(),
+        )
+    }
+
+    /// The whole loop, written correctly once so you do not have to.
+    ///
+    /// `handle_updates` runs immediately, and then again every time a peer
+    /// touches one of your edges. Handle *everything* that changed in there:
+    /// anything that arrives while it runs is remembered, not lost.
+    ///
+    /// Returns whatever `handle_updates` breaks with.
+    pub fn run<Out>(&self, mut handle_updates: impl FnMut() -> ControlFlow<Out>) -> Out {
+        // NOTE: the watch is deliberately taken *before* the first call, and
+        // `wait` hands back a watch taken at the instant it woke up, so every
+        // call is covered by a watch that predates it.
+        let mut watch = self.watch();
+
+        loop {
+            match handle_updates() {
+                ControlFlow::Break(out) => return out,
+                ControlFlow::Continue(()) => watch = self.wait(watch),
+            }
+        }
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, NodeState> {
+        // The state is one counter, so a peer that panicked mid-poke can not have
+        // left it in a nonsense state. Ignoring the poison keeps one crashed
+        // thread from taking down the whole tree.
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Identifies the node, so a [`Watch`] can check it came from the right one.
+    fn id(&self) -> usize {
+        Arc::as_ptr(&self.inner) as usize
+    }
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Panics if the calling thread is about to fall asleep holding an edge, which
+/// would stop its peer from ever writing to it, and therefore from ever waking
+/// this thread up.
+fn assert_can_sleep() {
+    let held = HELD_EDGES.with(Cell::get);
+
+    assert!(
+        held == 0,
+        "tried to sleep while holding {held} edge(s): \
+         the peer can not write to an edge you are holding, \
+         so it could never wake you up. \
+         Drop the guard(s) first (or use `quiet_mut` if you meant to consume)."
+    );
+}
+
+/// A snapshot of how much a node has been told, taken *before* it handles its
+/// edges and handed to [`Node::wait`] after.
+///
+/// Passing it around by value is what makes "check, then sleep" a single step:
+/// there is no way to ask to sleep without saying what you already knew.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub struct Watch {
+    pokes: u64,
+    /// Which node this came from, so mixing them up is caught in debug builds.
+    node: usize,
+}
+
+/// A handle for waking a node up. Cheap to clone, and safe to hold across threads.
+#[derive(Debug, Clone)]
+pub struct Poker {
+    node: Arc<NodeInner>,
+}
+impl Poker {
+    /// Tells the node that something it cares about changed.
+    ///
+    /// Never blocks on anything but the node's own leaf lock, so it is always
+    /// safe to call, even from inside the peer's own critical sections.
+    pub fn poke(&self) {
+        let mut state = self
+            .node
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+
+        // (u64 does not realistically wrap, but there is nothing to gain by
+        // panicking if it somehow did: only *changes* to this number matter.)
+        state.pokes = state.pokes.wrapping_add(1);
+
+        // Notifying while still holding the lock is the version that is easiest
+        // to convince yourself is correct: the sleeper cannot be between its
+        // check and its sleep, because that check happens under this very lock.
+        //
+        // `notify_all` because nothing stops two threads from driving one node.
+        self.node.poked.notify_all();
+    }
+}
+
+/// One node's end of an edge: state shared with exactly one other node.
+///
+/// Writing through it wakes the node at the *other* end, so keep hold of your
+/// own end and hand the other one to your peer's thread. Cloning gives another
+/// handle to the *same* end (useful for callbacks that run on your thread).
+pub struct EdgeEnd<Shared> {
+    edge: Arc<Mutex<Shared>>,
+    peer: Poker,
+}
+// manual impls: deriving would demand `Shared: Clone`/`Shared: Debug`
+impl<Shared> Clone for EdgeEnd<Shared> {
+    fn clone(&self) -> Self {
+        Self {
+            edge: self.edge.clone(),
+            peer: self.peer.clone(),
+        }
+    }
+}
+impl<Shared> fmt::Debug for EdgeEnd<Shared> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EdgeEnd").finish_non_exhaustive()
+    }
+}
+impl<Shared> EdgeEnd<Shared> {
+    /// Takes exclusive access to the shared state, blocking until it is free.
+    ///
+    /// Mutating what you get back (through [`DerefMut`]) wakes the peer when the
+    /// guard is dropped. Only *reading* wakes nobody.
+    ///
+    /// Never hold two of these at once if you can help it, and never hold one
+    /// while sleeping ([`Node::wait`] will catch you).
+    pub fn lock(&self) -> EdgeGuard<'_, Shared> {
+        let shared = self.edge.lock().unwrap_or_else(PoisonError::into_inner);
+
+        EdgeGuard::new(shared, &self.peer)
+    }
+
+    /// [`lock`](EdgeEnd::lock), but gives up instead of blocking if the peer is
+    /// mid-write. For loops that would rather do something else than wait.
+    pub fn try_lock(&self) -> Option<EdgeGuard<'_, Shared>> {
+        let shared = match self.edge.try_lock() {
+            Ok(shared) => shared,
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => return None,
+        };
+
+        Some(EdgeGuard::new(shared, &self.peer))
+    }
+
+    /// Wakes the peer without touching the shared state.
+    ///
+    /// For "look again" signals that are not really a change to this edge.
+    pub fn poke_peer(&self) {
+        self.peer.poke();
+    }
+}
+
+/// Exclusive access to an edge's state.
+///
+/// Reading is free; the moment you take a `&mut` out of it, the peer gets woken
+/// when this is dropped. If you are *consuming* rather than producing (draining
+/// your inbox), use [`quiet_mut`](EdgeGuard::quiet_mut) so the peer keeps sleeping.
+pub struct EdgeGuard<'edge, Shared> {
+    /// `Option` so [`Drop`] can release the edge *before* waking the peer;
+    /// otherwise the peer wakes up only to block on the lock we still hold.
+    shared: Option<MutexGuard<'edge, Shared>>,
+    peer: &'edge Poker,
+    poke_on_unlock: bool,
+}
+impl<'edge, Shared> EdgeGuard<'edge, Shared> {
+    fn new(shared: MutexGuard<'edge, Shared>, peer: &'edge Poker) -> Self {
+        HELD_EDGES.with(|held| held.set(held.get() + 1));
+
+        Self {
+            shared: Some(shared),
+            peer,
+            poke_on_unlock: false,
+        }
+    }
+
+    /// Mutable access that does **not** wake the peer.
+    ///
+    /// Use it when the change is not news to them: draining a queue they wrote,
+    /// clearing a damage flag, marking their message as read. Waking them for
+    /// that is how two nodes end up notifying each other in a loop forever.
+    pub fn quiet_mut(&mut self) -> &mut Shared {
+        self.shared.as_mut().expect("guard is alive")
+    }
+
+    /// Wakes the peer when this guard is dropped, even if you only used
+    /// [`quiet_mut`](EdgeGuard::quiet_mut).
+    ///
+    /// For deciding *after* the fact that a change was worth reporting.
+    pub fn poke_peer(&mut self) {
+        self.poke_on_unlock = true;
+    }
+}
+impl<Shared> Deref for EdgeGuard<'_, Shared> {
+    type Target = Shared;
+
+    fn deref(&self) -> &Shared {
+        self.shared.as_ref().expect("guard is alive")
+    }
+}
+impl<Shared> DerefMut for EdgeGuard<'_, Shared> {
+    /// Taking a `&mut` counts as an update, so the peer is woken on unlock.
+    /// That is deliberate: forgetting to notify is the bug that started all this.
+    fn deref_mut(&mut self) -> &mut Shared {
+        self.poke_on_unlock = true;
+
+        self.shared.as_mut().expect("guard is alive")
+    }
+}
+impl<Shared> Drop for EdgeGuard<'_, Shared> {
+    fn drop(&mut self) {
+        // release the edge *first*, so the peer does not wake up just to block on it
+        drop(self.shared.take());
+
+        // `try_with` because a guard could outlive TLS during thread teardown
+        let _ = HELD_EDGES.try_with(|held| held.set(held.get() - 1));
+
+        if self.poke_on_unlock {
+            // The write is published (the lock above is released) *before* the
+            // poke lands, so a peer that misses the write is guaranteed to see
+            // the poke and come back for it.
+            self.peer.poke();
+        }
+    }
+}

--- a/singularity_common/sonamu_sync/tests/node_edge.rs
+++ b/singularity_common/sonamu_sync/tests/node_edge.rs
@@ -1,0 +1,310 @@
+//! Tests for the node-and-edge sync primitives.
+//!
+//! A lost update shows up as a thread that sleeps forever, so nearly every test
+//! here runs on its own thread behind a deadline: "hung" is the failure mode we
+//! are actually hunting.
+
+use sonamu_sync::node_edge::Node;
+use std::{
+    ops::ControlFlow,
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+const DEADLINE: Duration = Duration::from_secs(10);
+
+/// Runs `body` on another thread and fails if it does not finish in time.
+fn before_deadline<Out: Send + 'static>(body: impl FnOnce() -> Out + Send + 'static) -> Out {
+    let (finished, result) = mpsc::channel();
+
+    thread::spawn(move || finished.send(body()));
+
+    result
+        .recv_timeout(DEADLINE)
+        .expect("test never finished: an update was lost (or a thread panicked)")
+}
+
+/// The exact race the whole design exists for: the peer writes in the window
+/// between "I have handled everything" and "I am asleep".
+#[test]
+fn update_landing_before_the_sleep_is_not_lost() {
+    before_deadline(|| {
+        let node = Node::new();
+        let peer = Node::new();
+        let (mine, theirs) = node.connect_to(&peer, 0_u32);
+
+        // I look at my edges and find nothing...
+        let watch = node.watch();
+        assert_eq!(*mine.lock(), 0);
+
+        // ...and *right then*, before I get to sleep, the peer writes.
+        thread::spawn(move || *theirs.lock() = 1).join().unwrap();
+
+        // So this must not sleep.
+        let _ = node.wait(watch);
+        assert_eq!(*mine.lock(), 1);
+    });
+}
+
+/// Same race, but hammered from several edges at once, which is where sloppy
+/// flag-clearing schemes fall over.
+#[test]
+fn no_update_is_ever_lost_under_load() {
+    const WRITERS: u32 = 4;
+    const PER_WRITER: u32 = 500;
+
+    before_deadline(|| {
+        let node = Node::new();
+
+        let mut ends = Vec::new();
+        for writer in 0..WRITERS {
+            let peer = Node::new();
+            let (mine, theirs) = node.connect_to(&peer, Vec::<u32>::new());
+            ends.push(mine);
+
+            thread::spawn(move || {
+                // vary the timing so writes land all over the reader's loop,
+                // including inside the check-then-sleep window
+                let mut jitter = writer + 1;
+                for message in 0..PER_WRITER {
+                    theirs.lock().push(message);
+
+                    jitter ^= jitter << 13;
+                    jitter ^= jitter >> 17;
+                    jitter ^= jitter << 5;
+                    for _ in 0..(jitter % 8) {
+                        thread::yield_now();
+                    }
+                }
+            });
+        }
+
+        let mut received = 0;
+        node.run(|| {
+            for end in &ends {
+                // draining my own inbox is not news to the writer
+                received += end.lock().quiet_mut().drain(..).count() as u32;
+            }
+
+            if received == WRITERS * PER_WRITER {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
+    });
+}
+
+/// Every edge of a node has to be able to wake it, not just the last one touched.
+#[test]
+fn any_edge_wakes_the_node() {
+    before_deadline(|| {
+        let node = Node::new();
+
+        let ends: Vec<_> = (0..3)
+            .map(|_| {
+                let peer = Node::new();
+                node.connect_to(&peer, false)
+            })
+            .collect();
+
+        for (_, theirs) in &ends {
+            let theirs = theirs.clone();
+            // stagger them so the node genuinely sleeps between updates
+            thread::spawn(move || {
+                thread::sleep(Duration::from_millis(20));
+                *theirs.lock() = true;
+            });
+        }
+
+        let mut watch = node.watch();
+        while !ends.iter().all(|(mine, _)| *mine.lock()) {
+            watch = node.wait(watch);
+        }
+    });
+}
+
+#[test]
+fn reading_does_not_wake_the_peer() {
+    let node = Node::new();
+    let peer = Node::new();
+    let (mine, theirs) = node.connect_to(&peer, 7_u32);
+
+    let peer_watch = peer.watch();
+    let node_watch = node.watch();
+
+    assert_eq!(*mine.lock(), 7);
+    assert_eq!(*theirs.lock(), 7);
+
+    assert!(!peer.has_update(peer_watch), "a read woke the peer");
+    assert!(!node.has_update(node_watch), "a read woke the node");
+}
+
+#[test]
+fn writing_wakes_only_the_peer() {
+    let node = Node::new();
+    let peer = Node::new();
+    let (mine, _theirs) = node.connect_to(&peer, 0_u32);
+
+    let peer_watch = peer.watch();
+    let node_watch = node.watch();
+
+    *mine.lock() = 1;
+
+    assert!(peer.has_update(peer_watch), "the peer was not woken");
+    assert!(
+        !node.has_update(node_watch),
+        "a node woke itself up with its own write"
+    );
+}
+
+#[test]
+fn quiet_mut_does_not_wake_the_peer() {
+    let node = Node::new();
+    let peer = Node::new();
+    let (mine, _theirs) = node.connect_to(&peer, 0_u32);
+
+    let watch = peer.watch();
+    *mine.lock().quiet_mut() = 1;
+    assert!(!peer.has_update(watch), "`quiet_mut` woke the peer");
+
+    // ...unless you ask for it after the fact
+    let mut guard = mine.lock();
+    *guard.quiet_mut() = 2;
+    guard.poke_peer();
+    drop(guard);
+    assert!(peer.has_update(watch), "`poke_peer` did not wake the peer");
+}
+
+/// An update that arrives *while* the node is busy is remembered, not dropped.
+#[test]
+fn updates_during_handling_are_remembered() {
+    let node = Node::new();
+    let peer = Node::new();
+    let (mine, theirs) = node.connect_to(&peer, 0_u32);
+
+    let watch = node.watch(); // taken before handling, as the API insists
+
+    // handling the first update...
+    assert_eq!(*mine.lock(), 0);
+    // ...during which a second one arrives
+    *theirs.lock() = 1;
+
+    assert!(
+        node.has_update(watch),
+        "an update that arrived mid-handling was forgotten"
+    );
+}
+
+#[test]
+fn wait_times_out_when_nothing_happens() {
+    before_deadline(|| {
+        let node = Node::new();
+        let _ends = node.connect_to(&Node::new(), ());
+
+        let started = Instant::now();
+        let (watch, timed_out) = node.wait_timeout(node.watch(), Duration::from_millis(50));
+
+        assert!(timed_out, "claimed an update that never happened");
+        assert!(started.elapsed() >= Duration::from_millis(50));
+
+        // and it still works afterwards
+        let (_, timed_out) = node.wait_timeout(watch, Duration::from_millis(10));
+        assert!(timed_out);
+    });
+}
+
+#[test]
+fn a_node_can_wake_itself() {
+    before_deadline(|| {
+        let node = Node::new();
+        let poker = node.poker();
+
+        let watch = node.watch();
+        poker.poke();
+
+        let _ = node.wait(watch); // must not sleep
+    });
+}
+
+/// Both directions of one edge, plus a shutdown handshake: the shape real code
+/// will use.
+#[test]
+fn parent_and_child_can_talk_both_ways() {
+    #[derive(Default)]
+    struct Link {
+        to_parent: Vec<u32>,
+        stop: bool,
+    }
+
+    before_deadline(|| {
+        let parent = Node::new();
+        let child = Node::new();
+        let (parent_end, child_end) = parent.connect_to(&child, Link::default());
+
+        let child_thread = thread::spawn(move || {
+            let mut sent = 0;
+            child.run(|| {
+                let mut link = child_end.lock();
+
+                if link.stop {
+                    return ControlFlow::Break(sent);
+                }
+
+                if sent < 5 {
+                    sent += 1;
+                    link.to_parent.push(sent);
+                }
+
+                ControlFlow::Continue(())
+            })
+        });
+
+        let mut received = Vec::new();
+        parent.run(|| {
+            let mut link = parent_end.lock();
+            received.append(&mut link.quiet_mut().to_parent);
+
+            if received.len() < 5 {
+                // reading the outbox is not an update, but "your outbox is empty
+                // again" is: the child only sends once the parent has caught up
+                link.poke_peer();
+                return ControlFlow::Continue(());
+            }
+
+            link.stop = true; // `DerefMut`, so the child is woken on unlock
+            ControlFlow::Break(())
+        });
+
+        assert_eq!(received, vec![1, 2, 3, 4, 5]);
+        assert_eq!(child_thread.join().unwrap(), 5);
+    });
+}
+
+/// Sleeping while holding an edge is a guaranteed hang, so it is a panic instead.
+#[test]
+#[should_panic(expected = "tried to sleep while holding 1 edge(s)")]
+fn sleeping_while_holding_an_edge_panics() {
+    let node = Node::new();
+    let (mine, _theirs) = node.connect_to(&Node::new(), ());
+
+    let watch = node.watch();
+    let _guard = mine.lock();
+
+    let _ = node.wait(watch);
+}
+
+#[test]
+fn guards_stop_being_held_once_dropped() {
+    let node = Node::new();
+    let (mine, _theirs) = node.connect_to(&Node::new(), ());
+
+    for _ in 0..3 {
+        let guard = mine.lock();
+        drop(guard);
+    }
+
+    // would panic if the bookkeeping leaked
+    let _ = node.wait_timeout(node.watch(), Duration::from_millis(1));
+}


### PR DESCRIPTION
Each node gets its own lock+condvar guarding nothing but a poke counter, separate from the edge locks. You snapshot the counter (`Node::watch`) before handling your edges and hand it to `Node::wait` after, so the check and the sleep are one atomic step and a write that lands in between can no longer be lost.

Edges hand each endpoint its own `EdgeEnd`, so writing wakes the peer automatically on unlock (`quiet_mut` opts out for consuming reads), and node locks are leaves, so nothing new can deadlock. Sleeping while holding an edge is a guaranteed hang, so it panics instead.

Tests are written so a lost update shows up as a hang; verified they catch it by breaking `wait` on purpose (5 of 12 fail).